### PR TITLE
Re-add latest Docker tag.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: golang:1.6.2
+      - image: golang:latest # We suggest using a version tag for real projects
       - image: postgres:9.4.1
         environment:
           POSTGRES_USER: ubuntu
@@ -25,3 +25,9 @@ jobs:
             go test -v -race ./... | go-junit-report > /tmp/test-results/unit-tests.xml
       - store_test_results:
           path: /tmp/test-results
+      - run:
+          name: ""
+          command: |
+            if [ $NIGHTLY ]; then
+              echo "This is a nightly build."
+            fi


### PR DESCRIPTION
We should use latest for these demo projects because they are going to
be built daily. This can help us determine upstream changes to images
that we would need to adjust the demo for. I added a comment on not
using the latest tag for real projects.